### PR TITLE
Add NDFS tests with 'accepting'

### DIFF
--- a/tests/newAcceptingExamples/testNDFS3-accloop.imiprop
+++ b/tests/newAcceptingExamples/testNDFS3-accloop.imiprop
@@ -1,0 +1,1 @@
+property := #synth cycle_through(accepting);

--- a/tests/newAcceptingExamples/testNDFS4-accloop.imiprop
+++ b/tests/newAcceptingExamples/testNDFS4-accloop.imiprop
@@ -1,0 +1,1 @@
+property := #synth cycle_through(accepting or loc[pta] = l1 );


### PR DESCRIPTION
imitator-ns testNDFS-2.imi testNDFS4-accloop.imiprop -verbose low

produces the correct result, but along the way it reports:

    property := #synthcycle_through(False || loc[pta] = l1);

This looks fishy to me. The state predicate "accepting" has not been properly unfolded.