### PR TITLE
add CI configuration to compile imitator on OSX machines

### DIFF
--- a/.github/patches/META.ppl.patch
+++ b/.github/patches/META.ppl.patch
@@ -1,0 +1,11 @@
+--- METAS/META.ppl.orig	2022-05-12 18:53:06.000000000 +0200
++++ METAS/META.ppl	2022-05-12 18:52:58.000000000 +0200
+@@ -4,6 +4,6 @@
+ archive(byte)="ppl_ocaml.cma"
+ archive(native)="ppl_ocaml.cmxa"
+ requires=""
+-directory="/usr/lib/ppl"
+-linkopts = "-cclib -lppl -cclib -lppl_ocaml"
++#directory="/usr/lib/ppl"
++#linkopts = "-cclib -lppl -cclib -lppl_ocaml"
+ #  -cclib -lgmp -cclib -lgmpxx

--- a/.github/patches/clang5.patch
+++ b/.github/patches/clang5.patch
@@ -1,0 +1,24 @@
+--- src/Determinate_inlines.hh.orig
++++ src/Determinate_inlines.hh
+@@ -289,8 +289,8 @@
+ 
+ template <typename PSET>
+ template <typename Binary_Operator_Assign>
+-inline
+-Determinate<PSET>::Binary_Operator_Assign_Lifter<Binary_Operator_Assign>
++inline typename
++Determinate<PSET>::template Binary_Operator_Assign_Lifter<Binary_Operator_Assign>
+ Determinate<PSET>::lift_op_assign(Binary_Operator_Assign op_assign) {
+   return Binary_Operator_Assign_Lifter<Binary_Operator_Assign>(op_assign);
+ }
+--- src/OR_Matrix_inlines.hh.orig
++++ src/OR_Matrix_inlines.hh
+@@ -97,7 +97,7 @@
+ 
+ template <typename T>
+ template <typename U>
+-inline OR_Matrix<T>::Pseudo_Row<U>&
++inline typename OR_Matrix<T>::template Pseudo_Row<U>&
+ OR_Matrix<T>::Pseudo_Row<U>::operator=(const Pseudo_Row& y) {
+   first = y.first;
+ #if PPL_OR_MATRIX_EXTRA_DEBUG

--- a/.github/patches/gmp.patch
+++ b/.github/patches/gmp.patch
@@ -1,0 +1,95 @@
+diff --git a/Makefile b/Makefile
+index 2e54a3c..b357aa7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -5,7 +5,7 @@ OCAML_LIBDIR:= $(shell ocamlc -where)
+ # GMP_INCLUDES= -I/opt/gmp-4.1.2/include -I/users/absint2/local/include -I$(HOME)/packages/gmp/include
+ 
+ # GMP_LIBDIR=/opt/gmp-4.1.2/lib
+-DESTDIR= $(OCAML_LIBDIR)/gmp
++DESTDIR= $(shell opam var lib)/gmp
+ 
+ #RLIBFLAGS= -cclib "-Wl,-rpath $(GMP_LIBDIR)" # Linux, FreeBSD
+ #RLIBFLAGS= -cclib "-Wl,-R $(GMP_LIBDIR)" # Solaris
+@@ -13,10 +13,10 @@ DESTDIR= $(OCAML_LIBDIR)/gmp
+ 
+ # LIBFLAGS= -cclib -L. -cclib -L$(GMP_LIBDIR) $(RLIBFLAGS) \
+ #	-cclib -lmpfr -cclib -lgmp -cclib -L$(DESTDIR)
+-LIBFLAGS = -cclib -L$(shell pwd) -cclib -lgmp -cclib -lmpfr
++LIBFLAGS = -cclib -L. -cclib -lgmp -cclib -lmpfr 
+ 
+ #CC= icc
+-CFLAGS_MISC= -Wall -Wno-unused -Werror -g -O3
++CFLAGS_MISC= -Wall -Wno-unused -Werror -g -O3 -Wno-incompatible-pointer-types-discards-qualifiers
+ #CFLAGS_MISC=
+ CFLAGS_INCLUDE= -I $(OCAML_LIBDIR) $(GMP_INCLUDES)
+ CFLAGS= $(CFLAGS_MISC) $(CFLAGS_INCLUDE)
+diff --git a/gmp.ml b/gmp.ml
+index 678426d..c63d2b1 100644
+--- a/gmp.ml
++++ b/gmp.ml
+@@ -410,16 +410,18 @@ module F = struct
+   let to_string_base_digits ~base: base ~digits: digits x =
+     let mantissa, exponent =
+       to_string_exp_base_digits ~base: base ~digits: digits (abs x)
+-    in let sign = sgn x in
+-       if sign = 0 then "0" else
+-       ((if sign < 0 then "-" else "")
++    in
++    let sign = sgn x in
++    if sign = 0 then "0"
++    else
++      ((if sign < 0 then "-" else "")
+        ^ (let lm=String.length mantissa
+         in if lm > 1
+-           then let tmp = String.create (succ lm)
+-                in String.blit mantissa 0 tmp 0 1;
+-                   String.blit mantissa 1 tmp 2 (pred lm);
+-                   String.set tmp 1 '.';
+-                   tmp
++           then let tmp = Bytes.create (succ lm)
++                in Bytes.blit_string mantissa 0 tmp 0 1;
++                   Bytes.blit_string mantissa 1 tmp 2 (pred lm);
++                   Bytes.set tmp 1 '.';
++                   Bytes.to_string tmp
+            else mantissa)
+        ^ (if base <= 10 then "E" else "@")
+        ^ (string_of_int (pred exponent)));;
+@@ -603,19 +605,24 @@ module FR = struct
+      ~base: base ~digits: digits x =
+    let mantissa, exponent =
+      to_string_exp_base_digits ~mode: mode ~base: base ~digits: digits x
+-       in let i = (if (sgn x) < 0 then 1 else 0) in
+-       (if mantissa = "Inf"
+-          then "Inf"
+-          else (let lm=String.length mantissa
+-        in if lm > 1
+-           then let tmp = String.create (succ lm)
+-                in String.blit mantissa 0 tmp 0 (1+i);
+-                   String.blit mantissa (1+i) tmp (2+i) ((pred lm)-i);
+-                   String.set tmp (1+i) '.';
+-                   tmp
+-           else mantissa)
+-       ^ (if base <= 10 then "E" else "@")
+-       ^ (string_of_int (pred exponent)));;
++   in
++   let i = (if (sgn x) < 0 then 1 else 0) in
++   let prefix : string =
++     if mantissa = "Inf" then "Inf"
++     else
++       let lm=String.length mantissa in
++       if lm > 1 then
++         let tmp = Bytes.create (succ lm) in
++         Bytes.blit_string mantissa 0 tmp 0 (1+i);
++         Bytes.blit_string mantissa (1+i) tmp (2+i) ((pred lm)-i);
++         Bytes.set tmp (1+i) '.';
++         Bytes.to_string tmp
++       else mantissa
++   in
++   prefix
++   ^ (if base <= 10 then "E" else "@")
++   ^ (string_of_int (pred exponent))
++;;
+ 
+   let to_string = to_string_base_digits ~mode: GMP_RNDN ~base: 10 ~digits: 10;;
+ 

--- a/.github/patches/oasis-config.patch
+++ b/.github/patches/oasis-config.patch
@@ -1,0 +1,11 @@
+--- oasis-config.orig	2022-05-12 18:47:31.000000000 +0200
++++ oasis-config	2022-05-12 18:47:48.000000000 +0200
+@@ -34,7 +34,7 @@
+   MainIs:         src/IMITATOR.ml
+   BuildDepends:   gmp, extlib, ppl, str, unix, threads, fileutils
+ # CCLib:          -lstdc++
+-  CCLib:          -static '-lppl -ltinfo -lppl_ocaml -lstdc++ -lgmp -lgmpxx'
++  CCLib:          '-lppl -lppl_ocaml -lstdc++ -lgmp -lgmpxx'
+ 
+ # -static to have a static compiling (+ ' ' around)
+ # I removed -lcamlrun because I wrote "best" instead of "byte"

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,6 +1,9 @@
 # PPL version
 PPL_VERSION=1.2
 
+# Patches folder
+PATCH_FOLDER="${GITHUB_WORKSPACE}/.github/patches"
+
 if [[ "$RUNNER_OS" = "Linux" ]]; then
     sudo apt-get update -qq
     sudo apt-get install -qq wget unzip curl build-essential g++ m4 ocaml-native-compilers camlp4-extra ocaml oasis ocaml-findlib \
@@ -22,16 +25,53 @@ if [[ "$RUNNER_OS" = "Linux" ]]; then
         (cd ocaml-bytes; ./configure --prefix=/usr --libdir=/usr/lib/ocaml/; make; sudo make install)
         rm -rf ocaml-bytes
     fi
+elif [[ "$RUNNER_OS" = "macOS" ]]; then
+    brew install opam gmp plotutils ppl
+
+    # install opam and ocaml libraries
+    opam init -a
+    opam install -y extlib fileutils oasis
+    eval $(opam env)
+
+    # install mlgmp
+    git clone https://github.com/monniaux/mlgmp.git && cd mlgmp
+    git apply "${PATCH_FOLDER}/gmp.patch"
+    make && sudo make install && cd ..
+    rm -rf mlgmp
+    sudo cp METAS/META.gmp $(opam var lib)/gmp/META
 fi
 
 # installing PPL
 wget -q --no-check-certificate https://www.bugseng.com/products/ppl/download/ftp/releases/${PPL_VERSION}/ppl-${PPL_VERSION}.zip
 unzip -qq ppl-${PPL_VERSION}.zip
-(cd ppl-${PPL_VERSION}; ./configure --prefix=/usr; cd interfaces/OCaml; make -j 4; sudo make install)
+
+cd ppl-${PPL_VERSION}
+if [[ "$RUNNER_OS" = "Linux" ]]; then
+    ./configure --prefix=/usr
+elif [[ "$RUNNER_OS" = "macOS" ]]; then
+    # patch clang
+    patch -p0 < "${PATCH_FOLDER}/clang5.patch"
+
+    # compile ppl
+    ./configure --prefix=$(opam var prefix) --with-mlgmp=$(opam var lib)/gmp --disable-documentation --enable-interfaces=ocaml
+    make
+fi
+cd interfaces/OCaml && make -j 4 && sudo make install && cd ../../..
 rm -rf ppl-${PPL_VERSION}*
 
 # Build IMITATOR
-sudo cp METAS/META.ppl /usr/lib/ocaml/METAS/
+if [[ "$RUNNER_OS" = "Linux" ]]; then
+    sudo cp METAS/META.ppl /usr/lib/ocaml/METAS/
+elif [[ "$RUNNER_OS" = "macOS" ]]; then
+    # patch oasis
+    patch -p0 < "${PATCH_FOLDER}/oasis-config.patch"
+
+    # patch ppl META file
+    patch -p0 < "${PATCH_FOLDER}/META.ppl.patch"
+
+    echo $(ls -al)
+    sudo cp METAS/META.ppl $(opam var lib)/ppl/META
+fi
 
 if [[ "$DISTRIBUTED" = "True" ]]; then
     sh build-patator.sh

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -2,10 +2,10 @@
 
 cd bin
 
-if [[ "$RUNNER_OS" = "Linux" ]]; then
-    if [ -f "patator" ]; then
-        mv "patator" "patator-$TAG-amd64"
-    else
-        mv "imitator" "imitator-$TAG-amd64"
-    fi
+platform=`echo "${RUNNER_OS}" | sed 's/./\L&/g'`
+
+if [ -f "patator" ]; then
+    mv "patator" "patator-$TAG-${platform}-amd64"
+else
+    mv "imitator" "imitator-$TAG-${platform}-amd64"
 fi

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
+          - macos-12
     runs-on: ${{ matrix.os }}
     env:
       DISTRIBUTED: False

--- a/METAS/META.gmp
+++ b/METAS/META.gmp
@@ -1,0 +1,5 @@
+version = "20120224"
+description = "GMP"
+archive(byte) = "gmp.cma"
+archive(native) = "gmp.cmxa"
+exists_if = "gmp.cma"


### PR DESCRIPTION
This PR allows compiling `imitator` on OSX. Moreover, it uses `opam`, so it can be used to compile `imitator` on Linux